### PR TITLE
syncFetchWeather()からasyncFetchWeather()への変更

### DIFF
--- a/Yumemi-ios-training/Model/Fetcher.swift
+++ b/Yumemi-ios-training/Model/Fetcher.swift
@@ -13,10 +13,10 @@ final class Fetcher: Fetchable {
     weak var delegate: FetchableDelegate?
     
     func fetch() {
-        DispatchQueue.global().async { [weak self] in
-            do {
-                let weatherDataString = try YumemiWeather.syncFetchWeather("{\"area\": \"tokyo\", \"date\": \"2020-04-01T12:00:00+09:00\" }")
-                let weatherData = Data(weatherDataString.utf8)
+        YumemiWeather.asyncFetchWeather("{\"area\": \"tokyo\", \"date\": \"2020-04-01T12:00:00+09:00\" }") { [weak self] result in
+            switch result {
+            case .success(let jsonString):
+                let weatherData = Data(jsonString.utf8)
                 guard let weatherResponse = self?.convert(from: weatherData) else {
                     assertionFailure("convertに失敗")
                     self?.delegate?.fetch(self, didFailWithError: .unknownError)
@@ -31,16 +31,13 @@ final class Fetcher: Fetchable {
                 let maxTemperature = String(weatherResponse.maxTemp)
                 let weatherInformation = WeatherInformation(weather: weather, minTemperature: minTemperature, maxTemperature: maxTemperature)
                 self?.delegate?.fetch(self, didFetch: weatherInformation)
-            } catch let error as YumemiWeatherError {
+            case .failure(let error):
                 switch error {
                 case .invalidParameterError:
                     self?.delegate?.fetch(self, didFailWithError: .invalidParameterError)
                 case .unknownError:
                     self?.delegate?.fetch(self, didFailWithError: .unknownError)
                 }
-            } catch {
-                assertionFailure("予期せぬエラーが発生しました")
-                self?.delegate?.fetch(self, didFailWithError: .unknownError)
             }
         }
     }


### PR DESCRIPTION
## 目的
外部ライブラリYumemiWeatherのasyncFetchWeather()を試す
## 実装の概要
これまで`syncFetchWeather()`で書いていたところを`asyncFetchWeather()`に置き換えた。

## 不安なところ
一般的にこれは長い関数で分けるべきといえるかどうか。個人的には行数はあるものの処理としては単純であるので良いと思っている。

## 疑問に思ったこと
XCTestが壊れているmainブランチから生えたブランチなので、[hotfix-XCTest](https://github.com/Hyperbolic4183/YumemiWeather/pull/31)がマージされるまでCIテストは通らない。ブランチは[hotfix-XCTest](https://github.com/Hyperbolic4183/YumemiWeather/pull/31)から生やした方がよかったかどうか。